### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # JZBorderedView ![License MIT](https://go-shields.herokuapp.com/license-MIT-blue.png)
 ================
 
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/JZBorderedView/badge.png)](http://cocoapods.org/?q=JZBorderedView)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/p/JZBorderedView/badge.png)](http://cocoapods.org/?q=JZBorderedView)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/JZBorderedView/badge.png)](http://cocoapods.org/?q=JZBorderedView)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/p/JZBorderedView/badge.png)](http://cocoapods.org/?q=JZBorderedView)
 A UIView subclass with four configurable borders and separators via storyboard.
 
 ## Alternative of static UITableView
@@ -14,7 +14,7 @@ This might be the alternative solution you are looking for as static UITableView
 
 ##Installation
 
-Cocoapods
+CocoaPods
 
 	pod 'JZBorderedView', '~> 0.0.5'
   


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
